### PR TITLE
Merge bugfix into master to fix #7

### DIFF
--- a/mttkinter/mtTkinter.py
+++ b/mttkinter/mtTkinter.py
@@ -141,7 +141,7 @@ class _TkAttr(object):
                 if is_exception:
                     ex_type, ex_value, ex_tb = response
                     raise ex_type(ex_value, ex_tb)
-                return response_queue
+                return response
 
 
 def _Tk__init__(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='mttkinter',
     packages=['mttkinter'],
-    version='0.6.0',
+    version='0.6.1',
     description='A thread-safe wrapper around Tkinter for Python',
     author='mtTkinter authors',
     author_email='redfantom@outlook.com',

--- a/tests/test_mttkinter.py
+++ b/tests/test_mttkinter.py
@@ -37,11 +37,12 @@ class TestMTTkinter(TestCase):
         complicated, and usually not easily reproducible.
         """
         from mttkinter import mtTkinter
-        root = tk.Tk()
-        queue = Queue(1)
-        root.after(1000, lambda: DummyThread(root, queue, 1).start())
-        while queue.empty():
-            root.update()
+        for mode in (1, 3):
+            root = tk.Tk()
+            queue = Queue(1)
+            root.after(1000, lambda: DummyThread(root, queue, mode).start())
+            while queue.empty():
+                root.update()
         # If exit with 0, then clearly the test succeeded
 
     def test_threading_exception(self):
@@ -77,3 +78,6 @@ class DummyThread(threading.Thread):
                 return True
             self.queue.put(True)
             raise ValueError("Exception not correctly raised.")
+        elif self.mode == 3:
+            tk.BooleanVar(self.root)
+            self.queue.put(True)


### PR DESCRIPTION
I made an error in refactoring when porting to Python 3 and fixing PEP-8 violations. This caused errors when calling a Tkinter function with the response of another Tkinter function in a different thread, for example by creating a `BooleanVar` (or any other type of variable), which the tests have been updated for to include. See #7 for more details.